### PR TITLE
RequestHandler as standard Rack application

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,8 @@
 require "rubygems"
 require "bundler/setup"
 
-require File.join(File.expand_path('../', __FILE__), 'lib/dolphin')
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+require 'dolphin'
 
 Dolphin.load_setting
 

--- a/bin/dolphin_server
+++ b/bin/dolphin_server
@@ -90,7 +90,7 @@ module Dolphin
     # TODO: Chanage to rackup
 
     server_settings = Dolphin.settings['server']
-    RequestHandler.new(server_settings['host'], server_settings['port'])
+    RequestHandler.new(server_settings['host'], server_settings['port']).start
 
     Manager.run
   end

--- a/bin/dolphin_server
+++ b/bin/dolphin_server
@@ -31,6 +31,8 @@ rescue => e
   exit!
 end
 
+Signal.trap(:INT, "EXIT")
+
 require 'ltsv'
 require 'celluloid'
 

--- a/lib/dolphin.rb
+++ b/lib/dolphin.rb
@@ -4,8 +4,6 @@ require 'parseconfig'
 require 'ostruct'
 require 'extlib/blank'
 
-Signal.trap(:INT, "EXIT")
-
 $LOAD_PATH.unshift File.expand_path('../', __FILE__)
 
 module Dolphin

--- a/lib/dolphin/helpers/request_helper.rb
+++ b/lib/dolphin/helpers/request_helper.rb
@@ -6,61 +6,11 @@ module Dolphin
   module Helpers
     module RequestHelper
 
-      def attach_request_params(request)
-        raise "Unsuppoted Content-Type: #{request.env['Content-Type']}" unless request.env['Content-Type'] === 'application/json'
-        @params = {}
-        @notification_id = request.env['X-Notification-Id']
-        @message_type = request.env['X-Message-Type']
-        case request.method
-          when "POST"
-            v = request.input.to_a[0]
-            @params = MultiJson.load(v)
-          when "GET"
-            @params = parse_query_string(request.env["QUERY_STRING"])
-        end
-        @params
-      end
-
-      def run(request, &blk)
-        begin
-          attach_request_params(request)
-          logger :info, @params
-          blk.call
-        rescue LoadError => e
-          logger :error, e
-          [400, {}, MultiJson.dump({
-            :message => 'Request faild.'
-          })]
-        rescue => e
-          logger :error, e
-          [400, {}, MultiJson.dump({
-            :message => e.message
-          })]
-        end
-      end
-
-      def respond_with(data)
-        [200, {}, MultiJson.dump(data)]
-      end
-
       def required(name)
         case name
           when 'notification_id'
             raise 'Not found X-Notification-Id' if @notification_id.nil?
         end
-      end
-
-      private
-      def parse_query_string(query_string)
-        params = {}
-        unless query_string.blank?
-          parts = query_string.split('&')
-          parts.collect do |part|
-            key, value = part.split('=')
-            params.store(key, value)
-          end
-        end
-        params
       end
 
       def parse_time(time)

--- a/lib/dolphin/request_handler.rb
+++ b/lib/dolphin/request_handler.rb
@@ -1,145 +1,150 @@
 # -*- coding: utf-8 -*-
 
-require 'reel/app'
+require 'reel'
 require 'extlib/blank'
+require 'sinatra/base'
+require 'sinatra/respond_with'
 
 module Dolphin
-  class RequestHandler
-    include Reel::App
+  class RequestHandler < Rack::Handler::Reel
     include Dolphin::Util
-    include Dolphin::Helpers::RequestHelper
-
-    GET_EVENT_LIMIT = 30.freeze
 
     def initialize(host, port)
-
-      # TODO: Fix Celluloid.logger loading order.
+      super({:host=>host, :port=>port, :app=>RequestApp.new})
       logger :info, "Load settings in #{Dolphin.config}"
+    end
 
-      @server = Reel::Server.supervise_as(:reques_handler, host, port) do |connection|
+    def start
+      Celluloid::Actor[:request_handler_rack_pool] = ::Reel::RackWorker.pool(size: options[:workers], args: [self])
 
-        while request = connection.request
-          begin
-            logger :info, {
-              :host => request.headers["Host"],
-              :user_agent => request.headers["User-Agent"]
-            }
-            options = {
-              :method => request.method,
-              :input => request.body
-            }
-            options.merge!(request.headers)
-            status, headers_or_body, body = call Rack::MockRequest.env_for(request.url, options)
-            connection.respond status_symbol(status), headers_or_body, body.to_s
-          rescue => e
-            logger :error, e
-            break
-          end
-        end
+      ::Reel::Server.supervise_as(:request_handler, options[:host], options[:port]) do |connection|
+        Celluloid::Actor[:request_handler_rack_pool].handle(connection.detach)
       end
       logger :info, "Running on ruby #{RUBY_VERSION} with selected #{Celluloid::task_class}"
-      logger :info, "Listening on http://#{host}:#{port}"
-      @server
+      logger :info, "Listening on http://#{options[:host]}:#{options[:port]}"
     end
 
-    post '/events' do |request|
-      run(request) do
+    def stop
+      Celluloid::Actor[:request_handler].terminate!
+      Celluloid::Actor[:request_handler_rack_pool].terminate!
+    end
+  end
+  
+  class RequestApp < Sinatra::Base
+    include Dolphin::Util
+    helpers Dolphin::Helpers::RequestHelper
+    register Sinatra::RespondWith
 
-        raise 'Nothing parameters.' if @params.blank?
+    respond_to :json
+    GET_EVENT_LIMIT = 3000.freeze
+    
+    before do
+      logger :info, {
+        :host => request.host,
+        :user_agent => request.user_agent
+      }
+      @notification_id = request.env['HTTP_X_NOTIFICATION_ID']
+      @message_type = request.env['HTTP_X_MESSAGE_TYPE']
 
-        event = {}
-        event[:notification_id] = @notification_id
-        event[:message_type] = @message_type
-        event[:messages] = @params
-
-        events = worker.future.put_event(event)
-
-        # always success because put_event is async action.
-        response_params = {
-          :message => 'OK'
-        }
-        respond_with response_params
+      if request.post?
+        v = request.body
+        @params = MultiJson.load(v)
+      elsif request.get?
+        @params = request.params
       end
     end
 
-    get '/events' do |request|
-      run(request) do
-
-        limit = @params['limit'].blank? ? GET_EVENT_LIMIT : @params['limit'].to_i
-        raise "Requested over the limit. Limited to #{GET_EVENT_LIMIT}" if limit > GET_EVENT_LIMIT
-
-        params = {}
-        params[:count] = limit
-        params[:start_time] = parse_time(@params['start_time']) unless @params['start_time'].blank?
-        params[:start_id] = @params['start_id'] unless @params['start_id'].blank?
-
-        events = worker.get_event(params)
-        raise events.message if events.fail?
-
-        response_params = {
-          :results => events.message,
-          :message => 'OK'
-        }
-        response_params[:start_time] = @params['start_time'] unless @params['start_time'].blank?
-        respond_with response_params
-      end
+    error(RuntimeError) do
+      status(400)
+      respond_with {message:'Failed'}
     end
 
-    get '/notifications' do |request|
-      run(request) do
-        required 'notification_id'
-
-        notification = {}
-        notification[:id] = @notification_id
-
-        result = worker.get_notification(notification)
-        raise result.message if result.fail?
-        raise "Not found notification id" if result.message.nil?
-
-        response_params = {
-          :results => result.message,
-          :message => 'OK'
-        }
-        respond_with response_params
-      end
+    post '/events' do
+      raise 'Nothing parameters.' if @params.blank?
+      
+      event = {}
+      event[:notification_id] = @notification_id
+      event[:message_type] = @message_type
+      event[:messages] = @params
+      
+      events = worker.future.put_event(event)
+      
+      # always success because put_event is async action.
+      response_params = {
+        :message => 'OK'
+      }
+      respond_with response_params
     end
 
-    post '/notifications' do |request|
-      run(request) do
-        required 'notification_id'
-        raise 'Nothing parameters.' if @params.blank?
-
-        unsupported_sender_types = @params.keys - Sender::TYPES
-        raise "Unsuppoted sender types: #{unsupported_sender_types.join(',')}" unless unsupported_sender_types.blank?
-
-        notification = {}
-        notification[:id] = @notification_id
-        notification[:methods] = @params
-        result = worker.put_notification(notification)
-        raise result.message if result.fail?
-
-        response_params = {
-          :message => 'OK'
-        }
-        respond_with response_params
-      end
+    get '/events' do
+      limit = @params['limit'].blank? ? GET_EVENT_LIMIT : @params['limit'].to_i
+      raise "Requested over the limit. Limited to #{GET_EVENT_LIMIT}" if limit > GET_EVENT_LIMIT
+      
+      event = {}
+      event[:count] = limit
+      event[:start_time] = parse_time(@params['start_time']) unless @params['start_time'].blank?
+      event[:start_id] = @params['start_id'] unless @params['start_id'].blank?
+      
+      events = worker.get_event(event)
+      raise events.message if events.fail?
+      
+      response_params = {
+        :results => events.message,
+        :message => 'OK'
+      }
+      response_params[:start_time] = @params['start_time'] unless @params['start_time'].blank?
+      respond_with response_params
     end
 
-    delete '/notifications' do |request|
-      run(request) do
-        required 'notification_id'
+    get '/notifications' do
+      required 'notification_id'
+      
+      notification = {}
+      notification[:id] = @notification_id
+      
+      result = worker.get_notification(notification)
+      raise result.message if result.fail?
+      raise "Not found notification id" if result.message.nil?
+      
+      response_params = {
+        :results => result.message,
+        :message => 'OK'
+      }
+      respond_with response_params
+    end
 
-        notification = {}
-        notification[:id] = @notification_id
+    post '/notifications' do
+      required 'notification_id'
+      raise 'Nothing parameters.' if @params.blank?
+      
+      unsupported_sender_types = @params.keys - Sender::TYPES
+      raise "Unsuppoted sender types: #{unsupported_sender_types.join(',')}" unless unsupported_sender_types.blank?
+      
+      notification = {}
+      notification[:id] = @notification_id
+      notification[:methods] = @params
+      result = worker.put_notification(notification)
+      raise result.message if result.fail?
+      
+      response_params = {
+        :message => 'OK'
+      }
+      respond_with response_params
+    end
 
-        result = worker.delete_notification(notification)
-        raise result.message if result.fail?
-
-        response_params = {
-          :message => 'OK'
-        }
-        respond_with response_params
-      end
+    delete '/notifications' do
+      required 'notification_id'
+      
+      notification = {}
+      notification[:id] = @notification_id
+      
+      result = worker.delete_notification(notification)
+      raise result.message if result.fail?
+      
+      response_params = {
+        :message => 'OK'
+      }
+      respond_with response_params
     end
 
     private

--- a/lib/dolphin/version.rb
+++ b/lib/dolphin/version.rb
@@ -1,3 +1,3 @@
 module Dolphin
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/wakame-dolphin.gemspec
+++ b/wakame-dolphin.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'erubis', '= 2.7.0'
   spec.add_runtime_dependency 'mail-iso-2022-jp', '= 2.0.1'
   spec.add_runtime_dependency 'simple_uuid', '= 0.2.0'
+  spec.add_runtime_dependency 'sinatra', '~> 1.4.0'
+  spec.add_runtime_dependency 'sinatra-contrib', '~> 1.4.0'
 
   # Fixed version for reel
   spec.add_runtime_dependency 'celluloid', '= 0.12.4'

--- a/wakame-dolphin.gemspec
+++ b/wakame-dolphin.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-
+require 'dolphin/version'
 Gem::Specification.new do |spec|
   spec.name        = 'wakame-dolphin'
-  spec.version     = '0.0.2'
+  spec.version     = Dolphin::VERSION
   spec.platform    = Gem::Platform::RUBY
   spec.summary     = 'notification service'
   spec.description = 'notification service'

--- a/wakame-dolphin.gemspec
+++ b/wakame-dolphin.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'extlib', '~> 0.9.16'
   spec.add_runtime_dependency 'multi_json', '1.6.1'
   spec.add_runtime_dependency 'rake', '= 10.0.3'
-  spec.add_runtime_dependency 'octarine', '= 0.0.3'
   spec.add_runtime_dependency 'parseconfig', '= 1.0.2'
   spec.add_runtime_dependency 'erubis', '= 2.7.0'
   spec.add_runtime_dependency 'mail-iso-2022-jp', '= 2.0.1'


### PR DESCRIPTION
RequestHandler has several unexpected behavior due to the unfamilir with Reel::App framework. It is going to rewrite as normal rack application (sinatra).

This re-factoring activity goals following points:
- Accept simultaneous connection.
- Take 30 messages limit of response body away.
