### PR TITLE
Feature cassandra retry connection

### DIFF
--- a/lib/dolphin/data_stores/cassandra.rb
+++ b/lib/dolphin/data_stores/cassandra.rb
@@ -48,7 +48,7 @@ module Dolphin
           @connection = nil
           if @retry_count < @max_retry_count
             @retry_count += 1
-            logger :error, "retry connection..#{@retry_count}"
+            logger :error, "retry connection... (retry current #{@retry_count} < #{@max_retry_count})"
             sleep @retry_interval
             retry
           end

--- a/lib/dolphin/data_stores/cassandra.rb
+++ b/lib/dolphin/data_stores/cassandra.rb
@@ -48,7 +48,7 @@ module Dolphin
           @connection = nil
           if @retry_count < @max_retry_count
             @retry_count += 1
-            logger :error, "retry connection... (retry current #{@retry_count} < #{@max_retry_count})"
+            logger :info, "retry connection... (retry current #{@retry_count} < #{@max_retry_count})"
             sleep @retry_interval
             retry
           end

--- a/lib/dolphin/data_stores/cassandra.rb
+++ b/lib/dolphin/data_stores/cassandra.rb
@@ -44,13 +44,14 @@ module Dolphin
             return @connection
           end
         rescue ThriftClient::NoServersAvailable => e
-          logger :error, e
           @connection = nil
           if @retry_count < @max_retry_count
             @retry_count += 1
             logger :info, "retry connection... (retry current #{@retry_count} < #{@max_retry_count})"
             sleep @retry_interval
             retry
+          else
+            logger :error, "Reached max retry count. (retried #{@max_retry_count} times): #{e.message}"
           end
         rescue UnAvailableNodeException => e
           logger :error, e


### PR DESCRIPTION
in order to improve cassandra log handling.
- change loglevel about "retry connection": `error` -> `info`
- move error-log to if-statement.
